### PR TITLE
prh: add cmake rules to enable build with qt 6.10 where GuiPrivate ha…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,13 @@ else()
   target_link_libraries(${PROJECT_NAME} PRIVATE OBS::frontend-api)
 endif()
 
-find_package(Qt6 COMPONENTS Widgets Core)
+find_package(Qt6 COMPONENTS Widgets Core Gui GuiPrivate)
 if(BUILD_OUT_OF_TREE)
   if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
     find_package(Qt6 REQUIRED Gui)
   endif()
 endif()
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets Qt6::GuiPrivate)
 
 # Find and link CURL library
 find_package(CURL REQUIRED)


### PR DESCRIPTION
…s to be explicitly requested.

This is expected to be fixed in Qt 6.11 - but for now this is required to build - at least on linux.