### PR TITLE
Fix crash when switching scene collections

### DIFF
--- a/patch-notes-summary.md
+++ b/patch-notes-summary.md
@@ -1,3 +1,10 @@
+# StreamUP v2.3.2 - Patch Update
+
+## Bug Fixes
+- **Switching Scene Collections Could Take OBS Down** - Change to another scene collection and OBS would complain that not all sources could be cleared, then hang or close on you. StreamUP watches the scene you are working in so it can tell Streamer.bot and your Stream Deck what you have selected, and it was still holding on to that scene while OBS was trying to pack the old collection away. It lets go before the switch starts now, and picks the new scene up once the new collection has loaded. Same on the way out, so closing OBS is clean too.
+
+---
+
 # StreamUP v2.3.1 - Patch Update
 
 ## Bug Fixes

--- a/streamup.cpp
+++ b/streamup.cpp
@@ -364,6 +364,11 @@ obs_websocket_vendor vendor = nullptr;
 // the only source state with no built-in OBS event (lock/visibility already have
 // SceneItemLockStateChanged / SceneItemEnableStateChanged).
 static obs_source_t *g_streamup_sel_scene = nullptr; // hooked scene (owns a +1 ref)
+// True between SCENE_COLLECTION_CHANGING and SCENE_COLLECTION_CHANGED. The hook
+// owns a real reference to the live scene, so it has to let go before OBS clears
+// the collection, or OBS finds the scene still referenced, logs "Not all sources
+// were cleared when clearing scene data" and can take the whole app down with it.
+static bool g_streamup_sel_collection_changing = false;
 
 static void StreamUpEmitSelectionChanged()
 {
@@ -410,18 +415,30 @@ static void StreamUpOnItemState(void *, calldata_t *)
 	StreamUpEmitSourceStateChanged();
 }
 
+static void StreamUpUnhookSelectionScene()
+{
+	if (!g_streamup_sel_scene)
+		return;
+
+	signal_handler_t *osh = obs_source_get_signal_handler(g_streamup_sel_scene);
+	signal_handler_disconnect(osh, "item_select", StreamUpOnItemSelect, nullptr);
+	signal_handler_disconnect(osh, "item_deselect", StreamUpOnItemSelect, nullptr);
+	signal_handler_disconnect(osh, "item_locked", StreamUpOnItemState, nullptr);
+	signal_handler_disconnect(osh, "item_visible", StreamUpOnItemState, nullptr);
+	obs_source_release(g_streamup_sel_scene);
+	g_streamup_sel_scene = nullptr;
+}
+
 static void StreamUpHookSelectionScene()
 {
 	// Unhook the previously-hooked scene, if any.
-	if (g_streamup_sel_scene) {
-		signal_handler_t *osh = obs_source_get_signal_handler(g_streamup_sel_scene);
-		signal_handler_disconnect(osh, "item_select", StreamUpOnItemSelect, nullptr);
-		signal_handler_disconnect(osh, "item_deselect", StreamUpOnItemSelect, nullptr);
-		signal_handler_disconnect(osh, "item_locked", StreamUpOnItemState, nullptr);
-		signal_handler_disconnect(osh, "item_visible", StreamUpOnItemState, nullptr);
-		obs_source_release(g_streamup_sel_scene);
-		g_streamup_sel_scene = nullptr;
-	}
+	StreamUpUnhookSelectionScene();
+
+	// Never hook while the collection is being torn down or swapped in: the
+	// "current scene" at that point belongs to a collection on its way out.
+	if (g_streamup_sel_collection_changing)
+		return;
+
 	// Hook the current scene (obs_frontend_get_current_scene returns a new ref we keep).
 	obs_source_t *scene = obs_frontend_get_current_scene();
 	if (scene) {
@@ -437,8 +454,28 @@ static void StreamUpHookSelectionScene()
 static void StreamUpSelectionFrontendEvent(enum obs_frontend_event event, void *)
 {
 	switch (event) {
+	case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING:
+		// Drop the reference before OBS clears the old collection's scenes.
+		g_streamup_sel_collection_changing = true;
+		StreamUpUnhookSelectionScene();
+		break;
+	case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED:
+		g_streamup_sel_collection_changing = false;
+		StreamUpHookSelectionScene();
+		StreamUpEmitSelectionChanged();
+		StreamUpEmitSourceStateChanged();
+		break;
+	case OBS_FRONTEND_EVENT_EXIT:
+		// Same again for shutdown: OBS clears scene data on the way out.
+		g_streamup_sel_collection_changing = true;
+		StreamUpUnhookSelectionScene();
+		break;
 	case OBS_FRONTEND_EVENT_FINISHED_LOADING: // initial hook once OBS is up
 	case OBS_FRONTEND_EVENT_SCENE_CHANGED:     // re-hook + report on scene switch
+		// SCENE_CHANGED fires while a collection is loading, pointing at scenes
+		// that are still being built. Ignore those; CHANGED does the re-hook.
+		if (g_streamup_sel_collection_changing)
+			break;
 		StreamUpHookSelectionScene();
 		StreamUpEmitSelectionChanged();
 		StreamUpEmitSourceStateChanged();
@@ -451,15 +488,7 @@ static void StreamUpSelectionFrontendEvent(enum obs_frontend_event event, void *
 static void StreamUpSelectionCleanup()
 {
 	obs_frontend_remove_event_callback(StreamUpSelectionFrontendEvent, nullptr);
-	if (g_streamup_sel_scene) {
-		signal_handler_t *osh = obs_source_get_signal_handler(g_streamup_sel_scene);
-		signal_handler_disconnect(osh, "item_select", StreamUpOnItemSelect, nullptr);
-		signal_handler_disconnect(osh, "item_deselect", StreamUpOnItemSelect, nullptr);
-		signal_handler_disconnect(osh, "item_locked", StreamUpOnItemState, nullptr);
-		signal_handler_disconnect(osh, "item_visible", StreamUpOnItemState, nullptr);
-		obs_source_release(g_streamup_sel_scene);
-		g_streamup_sel_scene = nullptr;
-	}
+	StreamUpUnhookSelectionScene();
 }
 
 void SettingsDialog()


### PR DESCRIPTION
The SelectionChanged vendor hook holds a +1 reference on the current scene and only dropped it on `SCENE_CHANGED`. Switching scene collections left that reference alive while OBS cleared the old collection, so OBS logged "Not all sources were cleared when clearing scene data" and could hang or crash.

- Unhook and release on `SCENE_COLLECTION_CHANGING` and on `EXIT`.
- Re-hook on `SCENE_COLLECTION_CHANGED`.
- Ignore `SCENE_CHANGED` while a collection is loading, so a half-built scene is never hooked.

The hook was added in 2.3.0, which is why this reads as a return of #36. The original teardown guard is still in place in the Scene Organiser and the main dock, this code just never got one.

Fixes #48
